### PR TITLE
Removed CORBA & Added Build Instructions to README.md

### DIFF
--- a/OpenAMASE/src/Amase/avtas/amase/network/TcpServer.java
+++ b/OpenAMASE/src/Amase/avtas/amase/network/TcpServer.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.ListIterator;
 import javax.swing.JMenuBar;
 import javax.swing.JOptionPane;
-import org.omg.CORBA.UserException;
 
 /**
  *

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ To modify *OpenAMASE*, the Java JDK 1.8 or higher is required. All external libr
 requires are included in the `lib` folder. For convenience, Netbeans project files are included to allow
 developers a quick way to change and re-build *OpenAMASE*.
 
+## Building OpenAMASE
+
+run `ant jar` in `OpenAMASE\OpenAMASE`.
+
 ## Running *OpenAMASE*
 
 *OpenAMASE* has multiple options and configurations. For details, see `AMASE Tutorial.pptx` and `AmaseQuickstart.pdf`. In-depth


### PR DESCRIPTION
Removed CORBA import because it doesn't appear to be used, AMASE compiles without it, and the corba import made my build break.

Also added build instructions to README.md