### PR TITLE
Fix event concurrency issues

### DIFF
--- a/OpenAMASE/src/Amase/avtas/amase/network/EntityTcpServer.java
+++ b/OpenAMASE/src/Amase/avtas/amase/network/EntityTcpServer.java
@@ -87,7 +87,7 @@ public class EntityTcpServer {
     }
 
     protected void messageReceived(LMCPObject lmcp) {
-
+        
         if (lmcp instanceof AutomationResponse) {
             processAutomationResponse((AutomationResponse) lmcp);
         } else {
@@ -127,6 +127,8 @@ public class EntityTcpServer {
 
             while (isRunning) {
                 try {
+                    //TODO: The Java Socket types is NOT thread safe and there's no protection here for concurrent read/write
+                    // to the socket!
                     byte[] bytes = LMCPFactory.getMessageBytes(socket.getInputStream());
                     if (bytes.length > 0) {
                         avtas.lmcp.LMCPObject lmcpObject = LMCPFactory.getObject(bytes);


### PR DESCRIPTION
OpenAMASE management of events was not properly protected, leading to runtime issues and deadlock situations when running with the Daidalus branch in conjunction with OpenUxAS.  Added additional protections during event management which resulted in correcting the behavior.

"TODO" comments have been added in code for locations that could be improved in future fixes.