### PR TITLE
java 21 properties

### DIFF
--- a/OpenAMASE/nbproject/project.properties
+++ b/OpenAMASE/nbproject/project.properties
@@ -49,8 +49,8 @@ javac.deprecation=false
 javac.external.vm=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=21
-javac.target=21
+javac.source=11
+javac.target=11
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}

--- a/OpenAMASE/nbproject/project.properties
+++ b/OpenAMASE/nbproject/project.properties
@@ -49,8 +49,8 @@ javac.deprecation=false
 javac.external.vm=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.7
-javac.target=1.7
+javac.source=21
+javac.target=21
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}


### PR DESCRIPTION
Updated Amase java code and properties file to run successfully on Java 18 and 21.

This fixes the deprecated code/warnings issue.
This fixes the will not build on later java versions issue.  #23 